### PR TITLE
feat(closes OPEN-8574): session and user id support for the Conversat…

### DIFF
--- a/rbi/openlayer/integrations.rbi
+++ b/rbi/openlayer/integrations.rbi
@@ -8,13 +8,17 @@ module Openlayer
         params(
           client: T.untyped,
           openlayer_client: Openlayer::Client,
-          inference_pipeline_id: String
+          inference_pipeline_id: String,
+          session_id: T.nilable(String),
+          user_id: T.nilable(String)
         ).void
       end
       def self.trace_client(
         client,
         openlayer_client:,
-        inference_pipeline_id:
+        inference_pipeline_id:,
+        session_id: nil,
+        user_id: nil
       )
       end
     end


### PR DESCRIPTION
…ionalSearchService tracer

## Summary

Adds support for sessions and users for the Google ConversationalSearch tracer.

Both can be specified as kwargs when calling the trace function (`session_id` and `user_id`, respectively). 

Alternatively, we also try to automatically determine the session from the response body returned by Google. The `session_id` kwarg takes precendence over the auto-detected session id.

